### PR TITLE
Tag.doAfterBody() should return either EVAL_BODY_AGAIN or SKIP_BODY

### DIFF
--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -103,7 +103,7 @@ public class LocateTag extends TagSupport {
 
 	@Override
 	public int doAfterBody() throws JspException {
-		return emitOne() ? EVAL_BODY_AGAIN : EVAL_PAGE;
+		return emitOne() ? EVAL_BODY_AGAIN : SKIP_BODY;
 	}
 
 	@Override

--- a/src/test/java/org/webjars/taglib/LocateTagTest.java
+++ b/src/test/java/org/webjars/taglib/LocateTagTest.java
@@ -175,7 +175,7 @@ public class LocateTagTest {
 				assertEquals(IterationTag.EVAL_BODY_AGAIN,
 						locateTag.doAfterBody());
 			} else {
-				assertEquals(Tag.EVAL_PAGE, locateTag.doAfterBody());
+				assertEquals(Tag.SKIP_BODY, locateTag.doAfterBody());
 			}
 		}
 		assertEquals(Tag.EVAL_PAGE, locateTag.doEndTag());


### PR DESCRIPTION
Hello,

 While trying to use your taglib in a Freemarker-based project, I had an issue with the return value of doAfterBody(). It seems the EVAL_PAGE return value is invalid here indeed, cf. http://docs.oracle.com/cd/E17802_01/products/products/jsp/2.1/docs/jsp-2_1-pfd2/javax/servlet/jsp/tagext/IterationTag.html#doAfterBody%28%29 

Thanks
