### PR TITLE
Add script and link tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>webjars-locator</artifactId>
-			<version>0.3</version>
+			<version>0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>

--- a/src/main/java/org/webjars/taglib/LinkTag.java
+++ b/src/main/java/org/webjars/taglib/LinkTag.java
@@ -23,7 +23,7 @@ public class LinkTag extends SimpleTag {
 
     @Override
     public void doTagInternal() throws JspException, IOException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("<link ");
         sb.append(String.format("rel='%s' ", rel));
         if (null != media) sb.append(String.format("media='%s' ", media));

--- a/src/main/java/org/webjars/taglib/LinkTag.java
+++ b/src/main/java/org/webjars/taglib/LinkTag.java
@@ -28,7 +28,7 @@ public class LinkTag extends SimpleTag {
         sb.append(String.format("rel='%s' ", rel));
         if (null != media) sb.append(String.format("media='%s' ", media));
         sb.append(String.format("type='%s' ", type));
-        sb.append(String.format("href='%s/%s'/>", getContextPath(), getPath()));
+        sb.append(String.format("href='%s/%s'/>", getContextPath(), getFullPath()));
         out().print(sb.toString());
     }
 

--- a/src/main/java/org/webjars/taglib/LinkTag.java
+++ b/src/main/java/org/webjars/taglib/LinkTag.java
@@ -1,0 +1,61 @@
+package org.webjars.taglib;
+
+import javax.servlet.jsp.JspException;
+import java.io.IOException;
+
+/**
+ * Outputs a single link tag to a webjar resource, including the request context path.
+ * <p>
+ * Example output:
+ * {@code
+ * <link rel='stylesheet' type='text/css' href='/myappcontext/webjars/tablesorter/2.15.5/css/theme.default.css' />
+ * }
+ * </p>
+ *
+ * @author Ove Gram Nipen
+ */
+@SuppressWarnings("serial")
+public class LinkTag extends SimpleTag {
+
+    private String rel = "stylesheet";
+    private String type = "text/css";
+    private String media;
+
+    @Override
+    public void doTagInternal() throws JspException, IOException {
+        StringBuffer sb = new StringBuffer();
+        sb.append("<link ");
+        sb.append(String.format("rel='%s' ", rel));
+        if (null != media) sb.append(String.format("media='%s' ", media));
+        sb.append(String.format("type='%s' ", type));
+        sb.append(String.format("href='%s/%s'/>", getContextPath(), getPath()));
+        out().print(sb.toString());
+    }
+
+    /**
+     * Set the {@code rel} attribute in the generated link tag. Defaults to {@code rel='stylesheet'}.
+     *
+     * @param rel the value of the {@code rel} attribute in the generated link tag.
+     */
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    /**
+     * Set the {@code type} attribute in the generated link tag. Defaults to {@code type='text/css'}.
+     *
+     * @param type the value of the {@code type} attribute in the generated link tag.
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * Set the {@code media} attribute in the generated link tag. Not included by default.
+     *
+     * @param media the value of the {@code media} attribute in the generated link tag.
+     */
+    public void setMedia(String media) {
+        this.media = media;
+    }
+}

--- a/src/main/java/org/webjars/taglib/ScriptTag.java
+++ b/src/main/java/org/webjars/taglib/ScriptTag.java
@@ -1,0 +1,23 @@
+package org.webjars.taglib;
+
+import javax.servlet.jsp.JspException;
+import java.io.IOException;
+
+/**
+ * Outputs a single script tag.
+ * <p>
+ * Example output:
+ * {@code
+ * <script src='/myappcontext/webjars/tablesorter/2.15.5/js/tablesorter.min.js' />
+ * }
+ * </p>
+ *
+ * @author Ove Gram Nipen
+ */
+@SuppressWarnings("serial")
+public class ScriptTag extends SimpleTag {
+    @Override
+    public void doTagInternal() throws JspException, IOException {
+        out().print(String.format("<script src='%s/%s'></script>", getContextPath(), getPath()));
+    }
+}

--- a/src/main/java/org/webjars/taglib/ScriptTag.java
+++ b/src/main/java/org/webjars/taglib/ScriptTag.java
@@ -18,6 +18,6 @@ import java.io.IOException;
 public class ScriptTag extends SimpleTag {
     @Override
     public void doTagInternal() throws JspException, IOException {
-        out().print(String.format("<script src='%s/%s'></script>", getContextPath(), getPath()));
+        out().print(String.format("<script src='%s/%s'></script>", getContextPath(), getFullPath()));
     }
 }

--- a/src/main/java/org/webjars/taglib/SimpleTag.java
+++ b/src/main/java/org/webjars/taglib/SimpleTag.java
@@ -28,7 +28,7 @@ public abstract class SimpleTag extends SimpleTagSupport {
         return request.getContextPath();
     }
 
-    protected String getPath() {
+    protected String getFullPath() {
         String result = null == webjar ? locator.getFullPath(path) : locator.getFullPath(webjar, path);
         result = result.substring("META-INF/resources/".length());
         return result;

--- a/src/main/java/org/webjars/taglib/SimpleTag.java
+++ b/src/main/java/org/webjars/taglib/SimpleTag.java
@@ -1,0 +1,60 @@
+package org.webjars.taglib;
+
+import org.webjars.WebJarAssetLocator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import java.io.IOException;
+
+/**
+ * Base class for simple tags that output one html tag for a single WebJars asset
+ *
+ * @author Ove Gram Nipen
+ */
+public abstract class SimpleTag extends SimpleTagSupport {
+    protected String webjar, path;
+    protected WebJarAssetLocator locator = new WebJarAssetLocator();
+
+    protected JspWriter out() {
+        return getJspContext().getOut();
+    }
+
+    protected String getContextPath() {
+        PageContext context = (PageContext) getJspContext();
+        HttpServletRequest request = (HttpServletRequest) context.getRequest();
+        return request.getContextPath();
+    }
+
+    protected String getPath() {
+        String result = null == webjar ? locator.getFullPath(path) : locator.getFullPath(webjar, path);
+        result = result.substring("META-INF/resources/".length());
+        return result;
+    }
+
+    /**
+     * The path we're looking for, <i>e.g.</i> {@literal bootstrap.css}.
+     */
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+     * Restrict search to this webjar, <i>e.g.</i> {@literal bootstrap}. Useful when resources have the same name
+     * in several webjars.
+     */
+    public void setWebjar(String webjar) {
+        this.webjar = webjar;
+    }
+
+
+    @Override
+    public void doTag() throws JspException, IOException {
+        if (path == null) throw new JspException("Path must be set");
+        doTagInternal();
+    }
+
+    protected abstract void doTagInternal() throws JspException, IOException;
+}

--- a/src/main/java/org/webjars/taglib/SimpleTag.java
+++ b/src/main/java/org/webjars/taglib/SimpleTag.java
@@ -51,7 +51,7 @@ public abstract class SimpleTag extends SimpleTagSupport {
 
 
     @Override
-    public void doTag() throws JspException, IOException {
+    public final void doTag() throws JspException, IOException {
         if (path == null) throw new JspException("Path must be set");
         doTagInternal();
     }

--- a/src/main/resources/META-INF/webjars.tld
+++ b/src/main/resources/META-INF/webjars.tld
@@ -60,4 +60,63 @@ Useful e.g. for require.js. Default is false.</description>
 		</attribute>
 	</tag>
 
+	<tag>
+		<name>script</name>
+		<tag-class>org.webjars.taglib.ScriptTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<description>
+				Restrict search to a particular webjar. Useful when resources have the same name
+				in several webjars.
+			</description>
+			<name>webjar</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The path we're looking for, e.g. 'bootstrap.js'.</description>
+			<name>path</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+
+	<tag>
+		<name>link</name>
+		<tag-class>org.webjars.taglib.LinkTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<description>
+				Restrict search to a particular webjar. Useful when resources have the same name
+				in several webjars.
+			</description>
+			<name>webjar</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>The path we're looking for, e.g. 'bootstrap.js'.</description>
+			<name>path</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Link type. Defaults to rel="stylesheet".</description>
+			<name>rel</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Content type. Defaults to type="text/css".</description>
+			<name>type</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description>Media type, e.g., "screen" or "print". Not included by default.</description>
+			<name>media</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
 </taglib>

--- a/src/test/java/org/webjars/taglib/LinkTagTest.java
+++ b/src/test/java/org/webjars/taglib/LinkTagTest.java
@@ -1,0 +1,102 @@
+package org.webjars.taglib;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.webjars.WebJarAssetLocator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LinkTagTest {
+
+    @InjectMocks
+    private LinkTag linkTag = new LinkTag();
+
+    @Mock
+    private WebJarAssetLocator mockAssetLocator;
+
+    @Mock
+    private JspWriter mockJspWriter;
+
+    @Mock
+    private PageContext mockPageContext;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Before
+    public void setUp() throws Exception {
+        when(mockPageContext.getOut()).thenReturn(mockJspWriter);
+        when(mockPageContext.getRequest()).thenReturn(mockRequest);
+        when(mockRequest.getContextPath()).thenReturn("/mywebappcontext");
+    }
+
+    @Test(expected = JspException.class)
+    public void path_required() throws JspException, IOException {
+        linkTag.doTag();
+    }
+
+    @Test
+    public void can_get_css_with_webjar_and_path() throws Exception {
+        when(mockAssetLocator.getFullPath("tablesorter", "theme.default.css")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/css/theme.default.css");
+        linkTag.setPath("theme.default.css");
+        linkTag.setWebjar("tablesorter");
+        linkTag.doTag();
+        verifyOutContains("<link rel='stylesheet' type='text/css' href='/mywebappcontext/webjars/tablesorter/2.15.5/css/theme.default.css'/>");
+    }
+
+    @Test
+    public void can_get_css_with_only_path() throws Exception {
+        when(mockAssetLocator.getFullPath("theme.default.css")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/css/theme.default.css");
+        linkTag.setPath("theme.default.css");
+        linkTag.doTag();
+        verifyOutContains("<link rel='stylesheet' type='text/css' href='/mywebappcontext/webjars/tablesorter/2.15.5/css/theme.default.css'/>");
+    }
+
+    @Test
+    public void can_override_rel() throws Exception {
+        when(mockAssetLocator.getFullPath("theme.default.css")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/css/theme.default.css");
+        linkTag.setPath("theme.default.css");
+        linkTag.setRel("alternate stylesheet");
+        linkTag.doTag();
+        verifyOutContains("<link rel='alternate stylesheet' type='text/css' href='/mywebappcontext/webjars/tablesorter/2.15.5/css/theme.default.css'/>");
+    }
+
+    @Test
+    public void can_override_media() throws Exception {
+        when(mockAssetLocator.getFullPath("theme.default.css")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/css/theme.default.css");
+        linkTag.setPath("theme.default.css");
+        linkTag.setMedia("print");
+        linkTag.doTag();
+        verifyOutContains("<link rel='stylesheet' media='print' type='text/css' href='/mywebappcontext/webjars/tablesorter/2.15.5/css/theme.default.css'/>");
+    }
+
+    @Test
+    public void can_override_type() throws Exception {
+        when(mockAssetLocator.getFullPath("theme.default.xsl")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/css/theme.default.xsl");
+        linkTag.setPath("theme.default.xsl");
+        linkTag.setType("text/xsl");
+        linkTag.doTag();
+        verifyOutContains("<link rel='stylesheet' type='text/xsl' href='/mywebappcontext/webjars/tablesorter/2.15.5/css/theme.default.xsl'/>");
+    }
+
+    private void verifyOutContains(String expected) throws JspException, IOException {
+        verify(mockJspWriter).print(expected);
+    }
+}

--- a/src/test/java/org/webjars/taglib/ScriptTagTest.java
+++ b/src/test/java/org/webjars/taglib/ScriptTagTest.java
@@ -1,0 +1,72 @@
+package org.webjars.taglib;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.webjars.WebJarAssetLocator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import java.io.IOException;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScriptTagTest {
+
+    @InjectMocks
+    private ScriptTag scriptTag = new ScriptTag();
+
+    @Mock
+    private WebJarAssetLocator mockAssetLocator;
+
+    @Mock
+    private JspWriter mockJspWriter;
+
+    @Mock
+    private PageContext mockPageContext;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Before
+    public void setUp() throws Exception {
+        when(mockPageContext.getOut()).thenReturn(mockJspWriter);
+        when(mockPageContext.getRequest()).thenReturn(mockRequest);
+        when(mockRequest.getContextPath()).thenReturn("/mywebappcontext");
+    }
+
+    @Test(expected = JspException.class)
+    public void path_required() throws JspException, IOException {
+        scriptTag.doTag();
+    }
+
+    @Test
+    public void can_get_script_with_webjar_and_path() throws Exception {
+        when(mockAssetLocator.getFullPath("tablesorter", "jquery.tablesorter.js")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/js/jquery.tablesorter.js");
+        scriptTag.setPath("jquery.tablesorter.js");
+        scriptTag.setWebjar("tablesorter");
+        scriptTag.doTag();
+        verifyOutContains("<script src='/mywebappcontext/webjars/tablesorter/2.15.5/js/jquery.tablesorter.js'></script>");
+    }
+
+    @Test
+    public void can_get_script_with_only_path() throws Exception {
+        when(mockAssetLocator.getFullPath("jquery.tablesorter.js")).thenReturn(
+                "META-INF/resources/webjars/tablesorter/2.15.5/js/jquery.tablesorter.js");
+        scriptTag.setPath("jquery.tablesorter.js");
+        scriptTag.doTag();
+        verifyOutContains("<script src='/mywebappcontext/webjars/tablesorter/2.15.5/js/jquery.tablesorter.js'></script>");
+    }
+
+    private void verifyOutContains(String expected) throws JspException, IOException {
+        verify(mockJspWriter).print(expected);
+    }
+}

--- a/src/test/java/org/webjars/taglib/SimpleTagTest.java
+++ b/src/test/java/org/webjars/taglib/SimpleTagTest.java
@@ -1,0 +1,47 @@
+package org.webjars.taglib;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.webjars.MultipleMatchesException;
+import org.webjars.WebJarAssetLocator;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import java.io.IOException;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleTagTest {
+    @InjectMocks
+    private SimpleTag simpleTag = new SimpleTag() {
+        @Override
+        protected void doTagInternal() throws JspException, IOException {
+            getFullPath();
+        }
+    };
+
+    @Mock
+    private WebJarAssetLocator mockAssetLocator;
+
+    @Mock
+    private JspWriter mockJspWriter;
+
+    @Mock
+    private PageContext mockPageContext;
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    @Test(expected = MultipleMatchesException.class)
+    public void does_not_mask_multiple_matches_exception() throws Exception {
+        when(mockAssetLocator.getFullPath("foo.js")).thenThrow(MultipleMatchesException.class);
+        simpleTag.setPath("foo.js");
+        simpleTag.doTag();
+    }
+}


### PR DESCRIPTION
This PR pulls in webjars-locator 0.13 instead of 0.3, and adds link and script tags. 
# Usage

You can omit the webjar attribute if you know the path is unique.
## Use a javascript file in a JSP

```
<w:script webjar="tablesorter" path="jquery.tablesorter.js" />
```

This produces the following output:

```
<script src='/myappcontext/webjars/tablesorter/2.15.5/js/jquery.tablesorter.js'></script>
```
## Use a stylesheet in a JSP

```
<w:link webjar="tablesorter" path="theme.default.css" />
```

This produces the following output:

```
<link rel='stylesheet' type='text/css' href='/myappcontext/webjars/tablesorter/2.15.5/css/theme.default.css' />
```

You can override the media, rel and type attributes. 
