### PR TITLE
Added support for making dependencies version agnostic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ The default behavior is to remove the `META-INF/resources/webjars` prefix from r
 will output something like
 
 	/webjars/bootstrap/2.3.1/css/bootstrap
+	
+## Making dependencies version agnostic
+Since version 0.3, it is possible to reference resources contained in any WebJar (such as javascript and css files) without specifying the version number. To do so, you may reference a WebJar asset in your JSP like this:
+
+	<wj:locate path="bootstrap/css/bootstrap.css" versionAgnostic="true" />
+
+will output something like
+
+	/bootstrap/2.3.1/css/bootstrap.css
+
+Be sure to remove **ONLY** the version from the path, otherwise relative imports may not work.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ will output something like
 ## Making dependencies version agnostic
 Since version 0.3, it is possible to reference resources contained in any WebJar (such as javascript and css files) without specifying the version number. To do so, you may reference a WebJar asset in your JSP like this:
 
-	<wj:locate path="bootstrap/css/bootstrap.css" versionAgnostic="true" />
+	<wj:locate webjar="bootstrap" path="css/bootstrap.css" />
 
 will output something like
 
 	/bootstrap/2.3.1/css/bootstrap.css
 
-Be sure to remove **ONLY** the version from the path, otherwise relative imports may not work.
+Be sure to remove **ONLY** the version from the path, and to specifay the **EXACT** full path to the resource.

--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ will output something like
 
 	/bootstrap/2.3.1/css/bootstrap.css
 
-Be sure to remove **ONLY** the version from the path, and to specifay the **EXACT** full path to the resource.
+Be sure to remove **ONLY** the version from the path, and to specify the **EXACT** full path to the resource.

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>webjars-locator</artifactId>
-			<version>0.3</version>
+			<version>0.26</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,13 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator-core</artifactId>
+			<version>0.29</version>
+		</dependency>
+		<dependency>
+			<groupId>org.webjars</groupId>
 			<artifactId>webjars-locator</artifactId>
-			<version>0.26</version>
+			<version>0.28</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet.jsp</groupId>

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -135,9 +135,12 @@ public class LocateTag extends TagSupport {
 		}
 
 		if (path != null) {
-			int pos = path.indexOf("/");
-			if (versionAgnostic && pos != -1) {
-				result = Collections.singletonList(assetLocator.getFullPath(
+			if (versionAgnostic) {
+		        if (path.charAt(0) == '/') {
+		        	path = path.substring(1);
+		        }
+				int pos = path.indexOf("/");
+				result = Collections.singletonList(assetLocator.getFullPathExact(
 						path.substring(0, pos), path.substring(pos + 1)))
 						.iterator();
 			} else {

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -39,7 +39,7 @@ public class LocateTag extends TagSupport {
 	private Iterator<String> result;
 
 	/**
-	 * Whether the path we're looking for do not specify the version number.
+	 * Whether the path we're looking for does not contain the version number.
 	 *
 	 * <p>
 	 * Default is {@literal false}.

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -136,16 +136,16 @@ public class LocateTag extends TagSupport {
 
 		if (path != null) {
 			if (versionAgnostic) {
-		        if (path.charAt(0) == '/') {
-		        	path = path.substring(1);
-		        }
+				if (path.charAt(0) == '/') {
+					path = path.substring(1);
+				}
 				int pos = path.indexOf("/");
 				result = Collections.singletonList(assetLocator.getFullPathExact(
 						path.substring(0, pos), path.substring(pos + 1)))
 						.iterator();
 			} else {
-			result = Collections
-					.singletonList(assetLocator.getFullPath(path)).iterator();
+				result = Collections
+						.singletonList(assetLocator.getFullPath(path)).iterator();
 			}
 		} else {
 			result = assetLocator.listAssets(prefix).iterator();
@@ -179,9 +179,9 @@ public class LocateTag extends TagSupport {
 		}
 	}
 
-    public boolean getVersionAgnostic() {
-        return versionAgnostic;
-    }
+	public boolean getVersionAgnostic() {
+		return versionAgnostic;
+	}
 
 	public boolean getOmitExtension() {
 		return omitExtension;

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -1,10 +1,8 @@
 package org.webjars.taglib;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
@@ -39,14 +37,12 @@ public class LocateTag extends TagSupport {
 	private Iterator<String> result;
 
 	/**
-	 * Whether version information should be automatically added by this tag.
+	 * The id of the WebJar to search. If specified the path must be the exact
+	 * path of the file within the WebJar.
 	 *
-	 * <p>
-	 * Default is {@literal false}.
-	 * </p>
 	 * @since 0.3
-	*/
-	private boolean versionAgnostic = false;
+	 */
+	private String webjar;
 
 	/**
 	 * Whether to remove the resource extension before returning the result.
@@ -136,13 +132,9 @@ public class LocateTag extends TagSupport {
 		}
 
 		if (path != null) {
-			if (versionAgnostic) {
-				if (path.charAt(0) == '/') {
-					path = path.substring(1);
-				}
-				int pos = path.indexOf("/");
-				result = Collections.singletonList(assetLocator.getFullPathExact(
-						path.substring(0, pos), path.substring(pos + 1)))
+			if (webjar != null) {
+				result = Collections
+						.singletonList(assetLocator.getFullPathExact(webjar, path))
 						.iterator();
 			} else {
 				result = Collections
@@ -180,8 +172,8 @@ public class LocateTag extends TagSupport {
 		}
 	}
 
-	public boolean getVersionAgnostic() {
-		return versionAgnostic;
+	public String getWebjar() {
+		return webjar;
 	}
 
 	public boolean getOmitExtension() {
@@ -210,7 +202,7 @@ public class LocateTag extends TagSupport {
 		this.prefix = null;
 		this.var = null;
 		this.relativeTo = WebJarAssetLocator.WEBJARS_PATH_PREFIX;
-		this.versionAgnostic = false;
+		this.webjar = null;
 		this.omitExtension = false;
 		if (result.hasNext()) {
 			throw new IllegalStateException(
@@ -220,9 +212,9 @@ public class LocateTag extends TagSupport {
 		this.result = null;
 	}
 
-    public void setVersionAgnostic(boolean versionAgnostic) {
-        this.versionAgnostic = versionAgnostic;
-    }
+	public void setWebjar(String webjar) {
+		this.webjar = webjar;
+	}
 
 	public void setOmitExtension(boolean omitExtension) {
 		this.omitExtension = omitExtension;

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -39,7 +39,7 @@ public class LocateTag extends TagSupport {
 	private Iterator<String> result;
 
 	/**
-	 * Whether the path we're looking for does not contain the version number.
+	 * Whether version information should be automatically added by this tag.
 	 *
 	 * <p>
 	 * Default is {@literal false}.

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -39,6 +39,15 @@ public class LocateTag extends TagSupport {
 	private Iterator<String> result;
 
 	/**
+	 * Whether the path we're looking for do not specify the version number.
+	 *
+	 * <p>
+	 * Default is {@literal false}.
+	 * </p>
+	*/
+	private boolean versionAgnostic = false;
+
+	/**
 	 * Whether to remove the resource extension before returning the result.
 	 * Useful <i>e.g.</> for <a href="http://requirejs.org/">require.js</a>.
 	 * 
@@ -126,8 +135,15 @@ public class LocateTag extends TagSupport {
 		}
 
 		if (path != null) {
+			int pos = path.indexOf("/");
+			if (versionAgnostic && pos != -1) {
+				result = Collections.singletonList(assetLocator.getFullPath(
+						path.substring(0, pos), path.substring(pos + 1)))
+						.iterator();
+			} else {
 			result = Collections
 					.singletonList(assetLocator.getFullPath(path)).iterator();
+			}
 		} else {
 			result = assetLocator.listAssets(prefix).iterator();
 		}
@@ -160,6 +176,10 @@ public class LocateTag extends TagSupport {
 		}
 	}
 
+    public boolean getVersionAgnostic() {
+        return versionAgnostic;
+    }
+
 	public boolean getOmitExtension() {
 		return omitExtension;
 	}
@@ -186,6 +206,7 @@ public class LocateTag extends TagSupport {
 		this.prefix = null;
 		this.var = null;
 		this.relativeTo = WebJarAssetLocator.WEBJARS_PATH_PREFIX;
+		this.versionAgnostic = false;
 		this.omitExtension = false;
 		if (result.hasNext()) {
 			throw new IllegalStateException(
@@ -194,6 +215,10 @@ public class LocateTag extends TagSupport {
 		}
 		this.result = null;
 	}
+
+    public void setVersionAgnostic(boolean versionAgnostic) {
+        this.versionAgnostic = versionAgnostic;
+    }
 
 	public void setOmitExtension(boolean omitExtension) {
 		this.omitExtension = omitExtension;

--- a/src/main/java/org/webjars/taglib/LocateTag.java
+++ b/src/main/java/org/webjars/taglib/LocateTag.java
@@ -44,6 +44,7 @@ public class LocateTag extends TagSupport {
 	 * <p>
 	 * Default is {@literal false}.
 	 * </p>
+	 * @since 0.3
 	*/
 	private boolean versionAgnostic = false;
 

--- a/src/main/resources/META-INF/webjars.tld
+++ b/src/main/resources/META-INF/webjars.tld
@@ -52,7 +52,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Whether the path we're looking for does not contain the version number. 
+			<description>Whether version information should be automatically added by this tag. 
 Default is false.</description>
 			<name>versionAgnostic</name>
 			<required>false</required>

--- a/src/main/resources/META-INF/webjars.tld
+++ b/src/main/resources/META-INF/webjars.tld
@@ -52,7 +52,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Whether the path we're looking for do not specify the version number. 
+			<description>Whether the path we're looking for does not contain the version number. 
 Default is false.</description>
 			<name>versionAgnostic</name>
 			<required>false</required>

--- a/src/main/resources/META-INF/webjars.tld
+++ b/src/main/resources/META-INF/webjars.tld
@@ -52,9 +52,9 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>Whether version information should be automatically added by this tag. 
-Default is false.</description>
-			<name>versionAgnostic</name>
+			<description>The id of the WebJar to search. If specified the path must be the exact 
+path of the file within the WebJar.</description>
+			<name>webjar</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/src/main/resources/META-INF/webjars.tld
+++ b/src/main/resources/META-INF/webjars.tld
@@ -52,6 +52,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Whether the path we're looking for do not specify the version number. 
+Default is false.</description>
+			<name>versionAgnostic</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Whether to remove the resource extension before returning the result.
 Useful e.g. for require.js. Default is false.</description>
 			<name>omitExtension</name>

--- a/src/test/java/org/webjars/taglib/LocateTagTest.java
+++ b/src/test/java/org/webjars/taglib/LocateTagTest.java
@@ -158,15 +158,15 @@ public class LocateTagTest {
 	}
 	
 	@Test
-	public void test_version_agnostic_resolution() 
+	public void test_webjar() 
 			throws Exception {
 
 		when(mockAssetLocator.getFullPathExact("bootstrap" , "css/bootstrap.css")).thenReturn(
 				"META-INF/resources/webjars/bootstrap/2.3.1/css/bootstrap.css");
 		when(mockPageGontext.getOut()).thenReturn(mockJspWriter);
 
-		locateTag.setVersionAgnostic(true);
-		locateTag.setPath("bootstrap/css/bootstrap.css");
+		locateTag.setWebjar("bootstrap");
+		locateTag.setPath("css/bootstrap.css");
 
 		verifyOutContains("/bootstrap/2.3.1/css/bootstrap.css");
 

--- a/src/test/java/org/webjars/taglib/LocateTagTest.java
+++ b/src/test/java/org/webjars/taglib/LocateTagTest.java
@@ -156,6 +156,21 @@ public class LocateTagTest {
 		verifyOutContains("/bootstrap/2.2.1/bootstrap");
 
 	}
+	
+	@Test
+	public void test_version_agnostic_resolution() 
+			throws Exception {
+
+		when(mockAssetLocator.getFullPathExact("bootstrap" , "css/bootstrap.css")).thenReturn(
+				"META-INF/resources/webjars/bootstrap/2.3.1/css/bootstrap.css");
+		when(mockPageGontext.getOut()).thenReturn(mockJspWriter);
+
+		locateTag.setVersionAgnostic(true);
+		locateTag.setPath("bootstrap/css/bootstrap.css");
+
+		verifyOutContains("/bootstrap/2.3.1/css/bootstrap.css");
+
+	}
 
 	private void verifyOutContains(String expected) throws JspException,
 			IOException {


### PR DESCRIPTION
Similar as described for Spring MVC at http://www.webjars.org/documentation

The simplest usage is shown below:

```
<%@ taglib uri="http://www.webjars.org/tags" prefix="wj"%>

<wj:locate path="bootstrap/css/bootstrap.css" versionAgnostic="true" />
```

will output something like

```
/bootstrap/3.3.5/css/bootstrap.css
```

**NOTE**: Be sure to remove ONLY the version from the path, otherwise relative imports may not work.
